### PR TITLE
.github/workflows: Add Terraform CLI 1.1 testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
         # list whatever Terraform versions here you would like to support
         terraform:
           - '1.0.*'
+          - '1.1.*'
     steps:
       - uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
Encouraging new providers to also test against the newest Terraform CLI minor version. Over time as Terraform CLI's 1.0 compatibility is further solidified/proven, it is unclear whether testing each minor version should be necessary or encouraged.