### PR TITLE
.github/workflows: Add `go generate` testing to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,19 @@ jobs:
       - run: go mod download
       - run: go build -v .
 
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - uses: actions/checkout@v3
+      - run: go generate ./...
+      - name: git diff
+        run: |
+          git diff --compact-summary --exit-code || \
+            (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
+
   # Run acceptance tests in a matrix with Terraform CLI versions
   test:
     name: Terraform Provider Acceptance Tests


### PR DESCRIPTION
Reference: #24 

The `go test` command cannot detect any issues when running `go generate`. This ensures that any `go generate` commands can successfully execute, while also ensuring there are no dangling Git differences afterwards to prevent cases where the documentation is not symmetrically updated.