### PR TITLE
internal/provider: Add compilation based interface assertions

### DIFF
--- a/internal/provider/example_data_source.go
+++ b/internal/provider/example_data_source.go
@@ -9,6 +9,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+var _ tfsdk.DataSourceType = exampleDataSourceType{}
+var _ tfsdk.DataSource = exampleDataSource{}
+
 type exampleDataSourceType struct{}
 
 func (t exampleDataSourceType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {

--- a/internal/provider/example_data_source.go
+++ b/internal/provider/example_data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// Ensure provider defined types fully satisfy framework interfaces
 var _ tfsdk.DataSourceType = exampleDataSourceType{}
 var _ tfsdk.DataSource = exampleDataSource{}
 

--- a/internal/provider/example_resource.go
+++ b/internal/provider/example_resource.go
@@ -10,6 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
+var _ tfsdk.ResourceType = exampleResourceType{}
+var _ tfsdk.Resource = exampleResource{}
+
 type exampleResourceType struct{}
 
 func (t exampleResourceType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {

--- a/internal/provider/example_resource.go
+++ b/internal/provider/example_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
+// Ensure provider defined types fully satisfy framework interfaces
 var _ tfsdk.ResourceType = exampleResourceType{}
 var _ tfsdk.Resource = exampleResource{}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// Ensure provider defined types fully satisfy framework interfaces
 var _ tfsdk.Provider = &provider{}
 
 // provider satisfies the tfsdk.Provider interface and usually is included

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+var _ tfsdk.Provider = &provider{}
+
 // provider satisfies the tfsdk.Provider interface and usually is included
 // with all Resource and DataSource implementations.
 type provider struct {


### PR DESCRIPTION
This is a quick method for compilation errors to be raised should the types not satisfy the expected framework interfaces.