### PR TITLE
Cache Go dependencies and detect Go version in GitHub Action workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
+          cache: true
       # This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your 
       # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
       # secret. If you would rather own your own GPG handling, please fork this action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,6 @@ on:
 permissions:
   contents: write
 
-# Default values to simplify job configurations below.
-env:
-  # Go language version to use for building. This value should also be updated
-  # in the testing workflow if changed.
-  GO_VERSION: '1.17'
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -29,7 +23,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       # This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your 
       # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
       # secret. If you would rather own your own GPG handling, please fork this action

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
+          cache: true
       - run: go mod download
       - run: go build -v .
 
@@ -36,6 +37,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
+          cache: true
       - run: go generate ./...
       - name: git diff
         run: |
@@ -60,6 +62,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
+          cache: true
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ matrix.terraform }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,6 @@ on:
 permissions:
   contents: read
 
-# Default values to simplify job configurations below.
-env:
-  # Go language version to use for building. This value should also be updated
-  # in the release workflow if changed.
-  GO_VERSION: '1.17'
-
 jobs:
   # Ensure project builds before running testing matrix
   build:
@@ -28,20 +22,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
+          go-version-file: 'go.mod'
       - run: go mod download
       - run: go build -v .
 
   generate:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
+          go-version-file: 'go.mod'
       - run: go generate ./...
       - name: git diff
         run: |
@@ -62,14 +56,14 @@ jobs:
           - '1.0.*'
           - '1.1.*'
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
-      - uses: actions/checkout@v3
       - run: go mod download
       - env:
           TF_ACC: "1"


### PR DESCRIPTION
This PR contains the following:

- Enable caching of Go dependencies by default - see [here][0]
- Detect Go version using `go.mod` – see [here][1]

[0]: https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs
[1]: https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file