### PR TITLE
resource/example: Add defaulted attribute

### DIFF
--- a/docs/resources/scaffolding_example.md
+++ b/docs/resources/scaffolding_example.md
@@ -24,6 +24,7 @@ resource "scaffolding_example" "example" {
 ### Optional
 
 - `configurable_attribute` (String) Example configurable attribute
+- `defaulted` (String) Example configurable attribute with default value
 
 ### Read-Only
 

--- a/internal/provider/example_resource.go
+++ b/internal/provider/example_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -30,6 +31,7 @@ type ExampleResource struct {
 // ExampleResourceModel describes the resource data model.
 type ExampleResourceModel struct {
 	ConfigurableAttribute types.String `tfsdk:"configurable_attribute"`
+	Defaulted             types.String `tfsdk:"defaulted"`
 	Id                    types.String `tfsdk:"id"`
 }
 
@@ -46,6 +48,12 @@ func (r *ExampleResource) Schema(ctx context.Context, req resource.SchemaRequest
 			"configurable_attribute": schema.StringAttribute{
 				MarkdownDescription: "Example configurable attribute",
 				Optional:            true,
+			},
+			"defaulted": schema.StringAttribute{
+				MarkdownDescription: "Example configurable attribute with default value",
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("example value when not configured"),
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,

--- a/internal/provider/example_resource_test.go
+++ b/internal/provider/example_resource_test.go
@@ -17,6 +17,7 @@ func TestAccExampleResource(t *testing.T) {
 				Config: testAccExampleResourceConfig("one"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("scaffolding_example.test", "configurable_attribute", "one"),
+					resource.TestCheckResourceAttr("scaffolding_example.test", "defaulted", "example value when not configured"),
 					resource.TestCheckResourceAttr("scaffolding_example.test", "id", "example-id"),
 				),
 			},
@@ -29,7 +30,7 @@ func TestAccExampleResource(t *testing.T) {
 				// example code does not have an actual upstream service.
 				// Once the Read method is able to refresh information from
 				// the upstream service, this can be removed.
-				ImportStateVerifyIgnore: []string{"configurable_attribute"},
+				ImportStateVerifyIgnore: []string{"configurable_attribute", "defaulted"},
 			},
 			// Update and Read testing
 			{


### PR DESCRIPTION
Reference: https://developer.hashicorp.com/terraform/plugin/framework/resources/default

New example attribute highlights terraform-plugin-framework v1.2.0+ `Default` functionality for resource attributes. While the scaffolding code is not meant to be exhaustive of all available framework functionality, this new built-in feature is important enough to highlight.