### PR TITLE
Added GHA dependabot config for managing hashicorp actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  # Dependabot only updates hashicorp GHAs, external GHAs are managed by internal tooling (tsccr)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "hashicorp/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  # Dependabot only updates hashicorp GHAs, external GHAs are managed by internal tooling (tsccr)
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    # TODO: Dependabot only updates hashicorp GHAs in the template repository, the following lines can be removed for consumers of this template
     allow:
       - dependency-name: "hashicorp/*"


### PR DESCRIPTION
Ref: https://github.com/hashicorp/terraform-providers-devex-internal/issues/174

This one is a little awkward since it's a template repo. I made a TODO comment to indicate that this isn't really necessary for downstream repositories to keep.

The alternative is not keeping the GitHub actions up-to-date ☹️ 