### PR TITLE
Replacing "Terraform Cloud" with "HCP Terraform"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ before:
 builds:
 - env:
     # goreleaser does not work with CGO, it could also complicate
-    # usage by users in CI/CD systems like Terraform Cloud where
+    # usage by users in CI/CD systems like HCP Terraform where
     # they are unable to install libraries.
     - CGO_ENABLED=0
   mod_timestamp: '{{ .CommitTimestamp }}'


### PR DESCRIPTION
Following rebranding, the term "Terraform Cloud" has been replaced with "HCP Terraform" throughout.