### PR TITLE
chore: change to `govet`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,4 +24,4 @@ linters:
     - unconvert
     - unparam
     - unused
-    - vet
+    - govet


### PR DESCRIPTION
* vet is deprecated and has been replaced by govet.

```console
$ golangci-lint run
WARN [lintersdb] The name "vet" is deprecated. The linter has been renamed to: govet.
```

