### PR TITLE
all: Bump minimum Go module version to 1.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Once you've written your provider, you'll want to [publish it on the Terraform R
 ## Requirements
 
 - [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.0
-- [Go](https://golang.org/doc/install) >= 1.21
+- [Go](https://golang.org/doc/install) >= 1.22
 
 ## Building The Provider
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-provider-scaffolding-framework
 
-go 1.21
+go 1.22.7
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.19.4


### PR DESCRIPTION
Ref: https://github.com/hashicorp/terraform-providers-devex-internal/issues/182

Bumps the minimum Go module to 1.22.7