### PR TITLE
chore: replace with `copyloopvar`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ linters:
   enable:
     - durationcheck
     - errcheck
-    - exportloopref
+    - copyloopvar
     - forcetypeassert
     - godot
     - gofmt


### PR DESCRIPTION
Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar. 
See https://golangci-lint.run/usage/linters/#exportloopref