### PR TITLE
Update dependabot config to include tools directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,21 @@
-# See GitHub's documentation for more information on this file:
-# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+# See GitHub's docs for more information on this file:
+# https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
+  # Maintain dependencies for Go modules
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
+      # Check for updates to Go modules every weekday
       interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/tools"
+    schedule:
+      interval: "daily"
+  # Dependabot only updates hashicorp GHAs, external GHAs are managed by internal tooling (tsccr)
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    # TODO: Dependabot only updates hashicorp GHAs in the template repository, the following lines can be removed for consumers of this template
     allow:
       - dependency-name: "hashicorp/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
-# See GitHub's docs for more information on this file:
-# https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates
+# See GitHub's documentation for more information on this file:
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
 version: 2
 updates:
   # Maintain dependencies for Go modules

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,10 @@ updates:
     directory: "/tools"
     schedule:
       interval: "daily"
-  # Dependabot only updates hashicorp GHAs, external GHAs are managed by internal tooling (tsccr)
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    # TODO: Dependabot only updates hashicorp GHAs in the template repository, the following lines can be removed for consumers of this template
     allow:
       - dependency-name: "hashicorp/*"


### PR DESCRIPTION
Now that we have a separate `tools` directory, we should ensure the Go module dependencies are kept up-to-date there as well 👍🏻 