### PR TITLE
provider: migrate to the new plan and state check API

### DIFF
--- a/internal/provider/example_data_source_test.go
+++ b/internal/provider/example_data_source_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccExampleDataSource(t *testing.T) {
@@ -17,9 +20,13 @@ func TestAccExampleDataSource(t *testing.T) {
 			// Read testing
 			{
 				Config: testAccExampleDataSourceConfig,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.scaffolding_example.test", "id", "example-id"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"data.scaffolding_example.test",
+						tfjsonpath.New("id"),
+						knownvalue.StringExact("example-id"),
+					),
+				},
 			},
 		},
 	})

--- a/internal/provider/example_ephemeral_resource_test.go
+++ b/internal/provider/example_ephemeral_resource_test.go
@@ -26,7 +26,11 @@ func TestAccExampleEphemeralResource(t *testing.T) {
 			{
 				Config: testAccExampleEphemeralResourceConfig("example"),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue("echo.test", tfjsonpath.New("data").AtMapKey("value"), knownvalue.StringExact("token-123")),
+					statecheck.ExpectKnownValue(
+						"echo.test",
+						tfjsonpath.New("data").AtMapKey("value"),
+						knownvalue.StringExact("token-123"),
+					),
 				},
 			},
 		},

--- a/internal/provider/example_function_test.go
+++ b/internal/provider/example_function_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
@@ -24,9 +26,12 @@ func TestExampleFunction_Known(t *testing.T) {
 					value = provider::scaffolding::example("testvalue")
 				}
 				`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckOutput("test", "testvalue"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue(
+						"test",
+						knownvalue.StringExact("testvalue"),
+					),
+				},
 			},
 		},
 	})
@@ -69,9 +74,12 @@ func TestExampleFunction_Unknown(t *testing.T) {
 					value = provider::scaffolding::example(terraform_data.test.output)
 				}
 				`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckOutput("test", "testvalue"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue(
+						"test",
+						knownvalue.StringExact("testvalue"),
+					),
+				},
 			},
 		},
 	})

--- a/internal/provider/example_resource_test.go
+++ b/internal/provider/example_resource_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccExampleResource(t *testing.T) {
@@ -18,11 +21,23 @@ func TestAccExampleResource(t *testing.T) {
 			// Create and Read testing
 			{
 				Config: testAccExampleResourceConfig("one"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("scaffolding_example.test", "configurable_attribute", "one"),
-					resource.TestCheckResourceAttr("scaffolding_example.test", "defaulted", "example value when not configured"),
-					resource.TestCheckResourceAttr("scaffolding_example.test", "id", "example-id"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"scaffolding_example.test",
+						tfjsonpath.New("id"),
+						knownvalue.StringExact("example-id"),
+					),
+					statecheck.ExpectKnownValue(
+						"scaffolding_example.test",
+						tfjsonpath.New("defaulted"),
+						knownvalue.StringExact("example value when not configured"),
+					),
+					statecheck.ExpectKnownValue(
+						"scaffolding_example.test",
+						tfjsonpath.New("configurable_attribute"),
+						knownvalue.StringExact("one"),
+					),
+				},
 			},
 			// ImportState testing
 			{
@@ -38,9 +53,23 @@ func TestAccExampleResource(t *testing.T) {
 			// Update and Read testing
 			{
 				Config: testAccExampleResourceConfig("two"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("scaffolding_example.test", "configurable_attribute", "two"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"scaffolding_example.test",
+						tfjsonpath.New("id"),
+						knownvalue.StringExact("example-id"),
+					),
+					statecheck.ExpectKnownValue(
+						"scaffolding_example.test",
+						tfjsonpath.New("defaulted"),
+						knownvalue.StringExact("example value when not configured"),
+					),
+					statecheck.ExpectKnownValue(
+						"scaffolding_example.test",
+						tfjsonpath.New("configurable_attribute"),
+						knownvalue.StringExact("two"),
+					),
+				},
 			},
 			// Delete testing automatically occurs in TestCase
 		},


### PR DESCRIPTION
As [mentioned](https://developer.hashicorp.com/terraform/plugin/testing/acceptance-tests/teststep#legacy-check-function) in the acceptance tests documentation, [Check](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/helper/resource#TestStep:~:text=on%20this%20step.-,Check,-TestCheckFunc%0A%0A%09//%20Destroy%20will) is now legacy and has been replaced by the new [plan](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing@v1.11.0/plancheck) and [state](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing@v1.11.0/statecheck) check APIs.

This change migrates from the legacy plugin testing API to the new plan and state check API, which brings improved testing capabilities.

This makes it easier for provider developers to adopt these new APIs.

I’ve intentionally opted for using state check over a combination of both plan and state checks, as introducing both might overwhelm first-time provider developers using this scaffolding framework.