### PR TITLE
Fix max-issues-per-linter variable name

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:


### PR DESCRIPTION
This was fixed in the example in https://github.com/golangci/golangci-lint/pull/498 and is causing errors when the action is updated to 6.5.0.