### PR TITLE
Chore: golangci-lint fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:
@@ -20,8 +20,7 @@ linters:
     - nilerr
     - predeclared
     - staticcheck
-    - tenv
     - unconvert
     - unparam
     - unused
-    - govet
+    - usetesting


### PR DESCRIPTION
- Replace `max-per-linter` with `max-issues-per-linters`
- Replace `tenv` linter with `usetesting`