### PR TITLE
github: Use Dependabot to keep Actions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    # TODO: Dependabot only updates hashicorp GHAs in the template repository, the following lines can be removed for consumers of this template
-    allow:
-      - dependency-name: "hashicorp/*"


### PR DESCRIPTION

Now that TSCCR has gone away, Security's recommendation is that we go back to using Dependabot to keep all GitHub Actions updated.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>