### PR TITLE
Add back govet as part of golangci linter set

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - errcheck
     - forcetypeassert
     - godot
+    - govet
     - ineffassign
     - makezero
     - misspell


### PR DESCRIPTION
## Related Issue

None.

## Description

This appears to have accidentally been removed in 82387c9c6637ce91226c7abf19e48e533ced1d62.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None.